### PR TITLE
Migrate GitHub Actions to supported versions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,12 +18,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [18.x]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }} to build
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -31,7 +31,7 @@ jobs:
     - run: npm run build
 
     - name: Upload artifact (directory)
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ARTIFACT_NAME }}
         path: '${{ env.DIST_PATH }}'
@@ -46,7 +46,7 @@ jobs:
         filename: ../${{ env.ARTIFACT_NAME }}-${{ env.MODULE_VERSION }}.zip
 
     - name: Upload artifact (zip file)
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ARTIFACT_NAME }}-${{ env.MODULE_VERSION }}.zip
         path: ${{ env.ARTIFACT_NAME }}-${{ env.MODULE_VERSION }}.zip
@@ -67,14 +67,14 @@ jobs:
     steps:
 
     - name: Download npm artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: ${{ env.ARTIFACT_NAME }}
         path: "artifacts/v${{ env.MODULE_VERSION }}"
 
 
     - name: Login to Azure CLI
-      uses: azure/login@v1
+      uses: azure/login@v2
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 


### PR DESCRIPTION
- actions/upload-artifact v2 → v4 (v2 deprecated, causing CI failure)
- actions/download-artifact v2 → v4
- actions/checkout v3 → v4
- actions/setup-node v3 → v4
- azure/login v1 → v2
- Node.js 14.x → 18.x (14 is EOL)